### PR TITLE
fix: parse addr use wrong function

### DIFF
--- a/pkg/networking/mac.go
+++ b/pkg/networking/mac.go
@@ -45,13 +45,13 @@ func OverrideHwAddress(logger *zap.Logger, netns ns.NetNS, macPrefix, iface stri
 	}
 
 	// we only focus on first element
-	nAddr, err := netip.ParsePrefix(ips[0].IP.String())
+	nAddr, err := netip.ParseAddr(ips[0].IP.String())
 	if err != nil {
 		logger.Error("failed to ParsePrefix", zap.Error(err))
 		return "", err
 	}
 
-	suffix, err := inetAton(nAddr.Addr())
+	suffix, err := inetAton(nAddr)
 	if err != nil {
 		logger.Error("failed to inetAton", zap.Error(err))
 		return "", err


### PR DESCRIPTION
#### What this PR does / why we need it:

➡️ I want set macPrefix but got error:

_> {"level":"ERROR","ts":"2023-08-31T17:06:07.128+0800","caller":"networking/mac.go:52","msg":"failed to ParsePrefix","Action":"Add","ContainerID":"740978ee3c4f8de88d35f44eee0b5ef5aa5333d95531697eaae84984e4ad537b","PodUID":"885ef2ab-132e-4241-8e2e-f290c7192bae","PodName":"sre-demo-769965497c-xqtlp","PodNamespace":"default","IfName":"eth0","error":"netip.ParsePrefix(\"10.246.132.202\"): no '/'"}_

➡️ My net-attach-def:
```
{
        "cniVersion": "0.3.1",
        "name": "macvlan-conf",
        "plugins": [
            {
                "type": "macvlan",
                "master": "br0",
                "mode": "bridge",
                "ipam": {
                    "type": "spiderpool"
                }
            },{
                  "type": "veth",
                  "cluster_cidr": ["172.16.0.0/12"],
                  "service_cidr": ["172.10.0.0/16"],
                  "hardware_prefix": "06:08"
              }
        ]
    }
```

➡️ Coordinator plugin is right：
https://github.com/spidernet-io/spiderpool/blob/main/pkg/networking/networking/mac.go

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

#### Special notes for your reviewer:
